### PR TITLE
Watcha  op269 partner admin in room can invite partner

### DIFF
--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -732,7 +732,7 @@ class RoomMembershipRestServlet(TransactionRestServlet):
     def on_POST(self, request, room_id, membership_action, txn_id=None):
         requester = yield self.auth.get_user_by_req(request, allow_guest=True, allow_partner=True)
 
-        if (requester.is_guest) and membership_action not in {
+        if requester.is_guest and membership_action not in {
             Membership.JOIN,
             Membership.LEAVE,
         }:


### PR DESCRIPTION
small fix for this issue:
tested :
partner can invite partner when admin of room
partner still does'nt have access to user directory
partner still can't create room