### PR TITLE
Watcha OP732 enable public room

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -681,10 +681,7 @@ class RoomCreationHandler(BaseHandler):
                 % (user_id,),
             )
 
-        """ watcha!
         visibility = config.get("visibility", None)
-        !watcha """
-        visibility = "private"  # watcha+
         is_public = visibility == "public"
 
         room_id = await self._generate_room_id(

--- a/synapse/rest/client/v1/room.py
+++ b/synapse/rest/client/v1/room.py
@@ -490,11 +490,6 @@ class PublicRoomListRestServlet(TransactionRestServlet):
             if server:
                 raise e
 
-        # watcha+
-        # disable pubic room
-        raise AuthError(403, "Directory is not available")
-        # +watcha
-
         limit = parse_integer(request, "limit", 0)
         since_token = parse_string(request, "since", None)
 
@@ -527,11 +522,6 @@ class PublicRoomListRestServlet(TransactionRestServlet):
 
     async def on_POST(self, request):
         await self.auth.get_user_by_req(request, allow_guest=True)
-
-        # watcha+
-        # disable pubic room
-        raise AuthError(403, "Directory is not available")
-        # +watcha
 
         server = parse_string(request, "server", default=None)
         content = parse_json_object_from_request(request)

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -625,7 +625,6 @@ class ThreepidRestServlet(RestServlet):
         self.auth = hs.get_auth()
         self.auth_handler = hs.get_auth_handler()
         self.datastore = self.hs.get_datastore()
-        self.account_activity_handler = hs.get_account_validity_handler() # watcha+
 
     async def on_GET(self, request):
         """ watcha!

--- a/tests/federation/test_complexity.py
+++ b/tests/federation/test_complexity.py
@@ -67,26 +67,6 @@ class RoomComplexityTests(unittest.FederatingHomeserverTestCase):
         complexity = channel.json_body["v1"]
         self.assertEqual(complexity, 1.23)
 
-    # watcha+
-    test_complexity_simple.skip = "Rooms are not public in Watcha thus this API is not working, see next test"
-
-    def test_complexity_failing_in_watcha_because_api_not_public(self):
-
-        u1 = self.register_user("u1", "pass")
-        u1_token = self.login("u1", "pass")
-
-        room_1 = self.helper.create_room_as(u1, tok=u1_token)
-        self.helper.send_state(
-            room_1, event_type="m.room.topic", body={"topic": "foo"}, tok=u1_token
-        )
-
-        # Get the room complexity
-        channel = self.make_request(
-            "GET", "/_matrix/federation/unstable/rooms/%s/complexity" % (room_1,)
-        )
-        self.assertEquals(404, channel.code)
-    # +watcha
-
     def test_join_too_large(self):
 
         u1 = self.register_user("u1", "pass")

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -133,7 +133,6 @@ class StateQueryTests(unittest.FederatingHomeserverTestCase):
         self.assertEquals(403, channel.code, channel.result)
         self.assertEqual(channel.json_body["errcode"], "M_FORBIDDEN")
 
-    test_without_event_id.skip = "Disabled for Watcha because private visibility of room scuttle the test. We have to find another way to force private visibility of rooms." # watcha+
 
 def _create_acl_event(content):
     return make_event_from_dict(

--- a/tests/handlers/test_admin.py
+++ b/tests/handlers/test_admin.py
@@ -50,7 +50,6 @@ class ExfiltrateData(unittest.HomeserverTestCase):
             self.user1, tok=self.token1, is_public=True
         )
         self.helper.send(room_id, body="Hello!", tok=self.token1)
-        self.helper.invite(room_id, self.user1, self.user2, tok=self.token1) # watcha+
         self.helper.join(room_id, self.user2, tok=self.token2)
         self.helper.send(room_id, body="Hello again!", tok=self.token1)
 
@@ -76,10 +75,7 @@ class ExfiltrateData(unittest.HomeserverTestCase):
         )
         self.assertEqual(counter[(EventTypes.Message, None)], 2)
         self.assertEqual(counter[(EventTypes.Member, self.user1)], 1)
-        """ watcha!
         self.assertEqual(counter[(EventTypes.Member, self.user2)], 1)
-        !watcha """
-        self.assertEqual(counter[(EventTypes.Member, self.user2)], 2) # watcha+
 
     def test_single_private_joined_room(self):
         """Tests that we correctly write state when we can't see all events in
@@ -93,7 +89,6 @@ class ExfiltrateData(unittest.HomeserverTestCase):
             tok=self.token1,
         )
         self.helper.send(room_id, body="Hello!", tok=self.token1)
-        self.helper.invite(room_id, self.user1, self.user2, tok=self.token1) # watcha+
         self.helper.join(room_id, self.user2, tok=self.token2)
         self.helper.send(room_id, body="Hello again!", tok=self.token1)
 
@@ -118,17 +113,13 @@ class ExfiltrateData(unittest.HomeserverTestCase):
         )
         self.assertEqual(counter[(EventTypes.Message, None)], 1)
         self.assertEqual(counter[(EventTypes.Member, self.user1)], 1)
-        """ watcha!
         self.assertEqual(counter[(EventTypes.Member, self.user2)], 1)
-        !watcha """
-        self.assertEqual(counter[(EventTypes.Member, self.user2)], 2) # watcha+
 
     def test_single_left_room(self):
         """Tests that we don't see events in the room after we leave.
         """
         room_id = self.helper.create_room_as(self.user1, tok=self.token1)
         self.helper.send(room_id, body="Hello!", tok=self.token1)
-        self.helper.invite(room_id, self.user1, self.user2, tok=self.token1) # watcha+
         self.helper.join(room_id, self.user2, tok=self.token2)
         self.helper.send(room_id, body="Hello again!", tok=self.token1)
         self.helper.leave(room_id, self.user2, tok=self.token2)
@@ -155,10 +146,7 @@ class ExfiltrateData(unittest.HomeserverTestCase):
         )
         self.assertEqual(counter[(EventTypes.Message, None)], 2)
         self.assertEqual(counter[(EventTypes.Member, self.user1)], 1)
-        """ watcha!
         self.assertEqual(counter[(EventTypes.Member, self.user2)], 2)
-        !watcha """
-        self.assertEqual(counter[(EventTypes.Member, self.user2)], 3) # watcha+
 
     def test_single_left_rejoined_private_room(self):
         """Tests that see the correct events in private rooms when we
@@ -172,12 +160,10 @@ class ExfiltrateData(unittest.HomeserverTestCase):
             tok=self.token1,
         )
         self.helper.send(room_id, body="Hello!", tok=self.token1)
-        self.helper.invite(room_id, self.user1, self.user2, tok=self.token1) # watcha+
         self.helper.join(room_id, self.user2, tok=self.token2)
         self.helper.send(room_id, body="Hello again!", tok=self.token1)
         self.helper.leave(room_id, self.user2, tok=self.token2)
         self.helper.send(room_id, body="Helloooooo!", tok=self.token1)
-        self.helper.invite(room_id, self.user1, self.user2, tok=self.token1) # watcha+
         self.helper.join(room_id, self.user2, tok=self.token2)
         self.helper.send(room_id, body="Helloooooo!!", tok=self.token1)
 
@@ -201,10 +187,7 @@ class ExfiltrateData(unittest.HomeserverTestCase):
         )
         self.assertEqual(counter[(EventTypes.Message, None)], 2)
         self.assertEqual(counter[(EventTypes.Member, self.user1)], 1)
-        """ watcha!
         self.assertEqual(counter[(EventTypes.Member, self.user2)], 3)
-        !watcha """
-        self.assertEqual(counter[(EventTypes.Member, self.user2)], 5) # watcha+
 
     def test_invite(self):
         """Tests that pending invites get handled correctly.

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -125,7 +125,6 @@ class TestCreateAlias(unittest.HomeserverTestCase):
         # Create a test user.
         self.test_user = self.register_user("user", "pass", admin=False)
         self.test_user_tok = self.login("user", "pass")
-        self.helper.invite(self.room_id, src=self.admin_user, tok=self.admin_user_tok, targ=self.test_user) # watcha+
         self.helper.join(room=self.room_id, user=self.test_user, tok=self.test_user_tok)
 
     def test_create_alias_joined_room(self):
@@ -190,7 +189,6 @@ class TestDeleteAlias(unittest.HomeserverTestCase):
         # Create a test user.
         self.test_user = self.register_user("user", "pass", admin=False)
         self.test_user_tok = self.login("user", "pass")
-        self.helper.invite(self.room_id, src=self.admin_user, tok=self.admin_user_tok, targ=self.test_user) # watcha+
         self.helper.join(room=self.room_id, user=self.test_user, tok=self.test_user_tok)
 
     def _create_alias(self, user):
@@ -466,16 +464,3 @@ class TestRoomListSearchDisabled(unittest.HomeserverTestCase):
             "PUT", b"directory/list/room/%s" % (room_id.encode("ascii"),), b"{}"
         )
         self.assertEquals(403, channel.code, channel.result)
-
-    # watcha+
-    test_disabling_room_list.skip = "Directory is disabled for Watcha"
-    def test_room_list_is_disabled_for_watcha(self):
-        self.room_list_handler.enable_room_list_search = True
-        self.directory_handler.enable_room_list_search = True
-
-        # Room list is enabled so we should get some results
-        channel = self.make_request("GET", b"publicRooms")
-
-        self.assertEquals(403, channel.code, channel.result)
-        self.assertEquals("Directory is not available", channel.json_body["error"])
-    # +watcha

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -210,11 +210,6 @@ class FederationTestCase(unittest.HomeserverTestCase):
 
         return join_event
 
-    # watcha+
-    test_rejected_message_event_state.skip = "Disable for Watcha"
-    test_rejected_state_event_state. skip = "Disable for Watcha"
-    # +watcha
-
 
 class EventFromPduTestCase(TestCase):
     def test_valid_json(self):

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -491,7 +491,6 @@ class PresenceJoinTestCase(unittest.HomeserverTestCase):
 
         # Create a room with two local users
         room_id = self.helper.create_room_as(self.user_id)
-        self.helper.invite(room_id, src=self.user_id, targ="@test2:server") # watcha+
         self.helper.join(room_id, "@test2:server")
 
         # Mark test2 as online, test will be offline with a last_active of 0
@@ -521,12 +520,9 @@ class PresenceJoinTestCase(unittest.HomeserverTestCase):
             self.presence_handler.current_state_for_user("@test2:server")
         )
         self.assertEqual(expected_state.state, PresenceState.ONLINE)
-        """ watcha!
         self.federation_sender.send_presence_to_destinations.assert_called_once_with(
             destinations=["server2"], states=[expected_state]
         )
-        !watcha """
-        self.federation_sender.send_presence_to_destinations.assert_not_called() # watcha+
 
         #
         # Test that only the new server gets sent presence and not existing servers
@@ -536,12 +532,9 @@ class PresenceJoinTestCase(unittest.HomeserverTestCase):
         self._add_new_user(room_id, "@bob:server3")
 
         self.federation_sender.send_presence.assert_not_called()
-        """ watcha!
         self.federation_sender.send_presence_to_destinations.assert_called_once_with(
             destinations=["server3"], states=[expected_state]
         )
-        !watcha """
-        self.federation_sender.send_presence_to_destinations.assert_not_called() # watcha+
 
     def test_remote_gets_presence_when_local_user_joins(self):
         # We advance time to something that isn't 0, as we use 0 as a special
@@ -579,7 +572,6 @@ class PresenceJoinTestCase(unittest.HomeserverTestCase):
         self.federation_sender.reset_mock()
 
         # Join local user to room
-        self.helper.invite(room_id, src=self.user_id, targ="@test2:server") # watcha+
         self.helper.join(room_id, "@test2:server")
 
         self.reactor.pump([0])  # Wait for presence updates to be handled
@@ -592,16 +584,9 @@ class PresenceJoinTestCase(unittest.HomeserverTestCase):
             self.presence_handler.current_state_for_user("@test2:server")
         )
         self.assertEqual(expected_state.state, PresenceState.ONLINE)
-        """ watcha!
         self.federation_sender.send_presence_to_destinations.assert_called_once_with(
             destinations={"server2", "server3"}, states=[expected_state]
         )
-        !watcha """
-        # watcha+
-        self.federation_sender.send_presence_to_destinations.assert_called_once_with(
-            destinations=set(), states=[expected_state]
-        )
-        # +watcha
 
     def _add_new_user(self, room_id, user_id):
         """Add new user to the room by creating an event and poking the federation API.
@@ -635,16 +620,5 @@ class PresenceJoinTestCase(unittest.HomeserverTestCase):
         self.get_success(self.federation_handler.on_receive_pdu(hostname, event))
 
         # Check that it was successfully persisted.
-        """ watcha!
-        makes sense that remote event is not persisted.
-        .. but not enough to make the test work. disabled below.
         self.get_success(self.store.get_event(event.event_id))
         self.get_success(self.store.get_event(event.event_id))
-        !watcha """
-        # watcha+
-        from synapse.api.errors import NotFoundError
-        self.get_failure(
-            self.store.get_event(event.event_id),
-            NotFoundError
-        )
-        # +watcha

--- a/tests/handlers/test_stats.py
+++ b/tests/handlers/test_stats.py
@@ -298,7 +298,6 @@ class StatsRoomTests(unittest.HomeserverTestCase):
         self.assertIsNotNone(r2stats)
 
         # contains the default things you'd expect in a fresh room
-        """ watcha!
         self.assertEqual(
             r1stats["total_events"],
             EXPT_NUM_STATE_EVTS_IN_FRESH_PUBLIC_ROOM,
@@ -306,14 +305,6 @@ class StatsRoomTests(unittest.HomeserverTestCase):
             " You may need to update this if more state events are added to"
             " the room creation process.",
         )
-        !watcha """
-        # watcha+
-        self.assertEqual(
-            r1stats["total_events"]-1,
-            EXPT_NUM_STATE_EVTS_IN_FRESH_PUBLIC_ROOM,
-        )
-        # +watcha
-
         self.assertEqual(
             r2stats["total_events"],
             EXPT_NUM_STATE_EVTS_IN_FRESH_PRIVATE_ROOM,
@@ -322,16 +313,9 @@ class StatsRoomTests(unittest.HomeserverTestCase):
             " the room creation process.",
         )
 
-        """ watcha! 
         self.assertEqual(
             r1stats["current_state_events"], EXPT_NUM_STATE_EVTS_IN_FRESH_PUBLIC_ROOM
         )
-        !watcha """
-        # watcha+
-        self.assertEqual(
-            r1stats["current_state_events"]-1, EXPT_NUM_STATE_EVTS_IN_FRESH_PUBLIC_ROOM
-        )    
-        # +watcha
         self.assertEqual(
             r2stats["current_state_events"], EXPT_NUM_STATE_EVTS_IN_FRESH_PRIVATE_ROOM
         )
@@ -468,12 +452,10 @@ class StatsRoomTests(unittest.HomeserverTestCase):
 
         r1stats_ante = self._get_current_stats("room", r1)
 
-        self.helper.invite(r1, u1, u2, tok=u1token) # watcha+
         self.helper.join(r1, u2, tok=u2token)
 
         r1stats_post = self._get_current_stats("room", r1)
 
-        """ watcha!
         self.assertEqual(r1stats_post["total_events"] - r1stats_ante["total_events"], 1)
         self.assertEqual(
             r1stats_post["current_state_events"] - r1stats_ante["current_state_events"],
@@ -482,17 +464,6 @@ class StatsRoomTests(unittest.HomeserverTestCase):
         self.assertEqual(
             r1stats_post["joined_members"] - r1stats_ante["joined_members"], 1
         )
-        !watcha """
-        # watcha+
-        self.assertEqual(r1stats_post["total_events"]-1 - r1stats_ante["total_events"], 1)
-        self.assertEqual(
-            r1stats_post["current_state_events"] - r1stats_ante["current_state_events"],
-            1,
-        )
-        self.assertEqual(
-            r1stats_post["joined_members"] - r1stats_ante["joined_members"], 1
-        )
-        # +watcha
 
     def test_join_after_leave(self):
         """
@@ -510,22 +481,17 @@ class StatsRoomTests(unittest.HomeserverTestCase):
 
         u2 = self.register_user("u2", "pass")
         u2token = self.login("u2", "pass")
-        self.helper.invite(r1, u1, u2, tok=u1token) # watcha+
 
         self.helper.join(r1, u2, tok=u2token)
         self.helper.leave(r1, u2, tok=u2token)
 
         r1stats_ante = self._get_current_stats("room", r1)
-        self.helper.invite(r1, u1, u2, tok=u1token) # watcha+
 
         self.helper.join(r1, u2, tok=u2token)
 
         r1stats_post = self._get_current_stats("room", r1)
 
-        """ watcha!
         self.assertEqual(r1stats_post["total_events"] - r1stats_ante["total_events"], 1)
-        !watcha """
-        self.assertEqual(r1stats_post["total_events"]-1 - r1stats_ante["total_events"], 1) # watcha+
         self.assertEqual(
             r1stats_post["current_state_events"] - r1stats_ante["current_state_events"],
             0,
@@ -620,7 +586,6 @@ class StatsRoomTests(unittest.HomeserverTestCase):
         u2 = self.register_user("u2", "pass")
         u2token = self.login("u2", "pass")
 
-        self.helper.invite(r1, u1, u2, tok=u1token) # watcha+
         self.helper.join(r1, u2, tok=u2token)
 
         r1stats_ante = self._get_current_stats("room", r1)
@@ -658,7 +623,6 @@ class StatsRoomTests(unittest.HomeserverTestCase):
         u2 = self.register_user("u2", "pass")
         u2token = self.login("u2", "pass")
 
-        self.helper.invite(r1, u1, u2, tok=u1token) # watcha+
         self.helper.join(r1, u2, tok=u2token)
 
         r1stats_ante = self._get_current_stats("room", r1)
@@ -710,17 +674,10 @@ class StatsRoomTests(unittest.HomeserverTestCase):
         u1stats = self._get_current_stats("user", u1)
 
         self.assertEqual(r1stats["joined_members"], 1)
-        """ watcha!
         self.assertEqual(
             r1stats["current_state_events"], EXPT_NUM_STATE_EVTS_IN_FRESH_PUBLIC_ROOM
         )
-        !watcha """
 
-        # watcha +
-        self.assertEqual(
-            r1stats["current_state_events"]-1, EXPT_NUM_STATE_EVTS_IN_FRESH_PUBLIC_ROOM
-        )
-        # +watcha
         self.assertEqual(u1stats["joined_rooms"], 1)
 
     def test_incomplete_stats(self):

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -132,7 +132,6 @@ class HTTPPusherTests(HomeserverTestCase):
         room = self.helper.create_room_as(user_id, tok=access_token)
 
         # The other user joins
-        self.helper.invite (room, user_id, other_user_id, tok=access_token) # watcha+
         self.helper.join(room=room, user=other_user_id, tok=other_access_token)
 
         # The other user sends some messages
@@ -236,8 +235,6 @@ class HTTPPusherTests(HomeserverTestCase):
         # Create a room
         room = self.helper.create_room_as(user_id, tok=access_token)
 
-        self.helper.invite (room, user_id, other_user_id, tok=access_token) # watcha+
-
         # The other user joins
         self.helper.join(room=room, user=other_user_id, tok=other_access_token)
 
@@ -305,7 +302,6 @@ class HTTPPusherTests(HomeserverTestCase):
         # (as encrypted messages in a 1:1 currently have tweaks applied
         #  so it doesn't properly exercise the condition of all encrypted
         #  messages need to be high).
-        self.helper.invite(room, user_id, yet_another_user_id, tok=access_token) # watcha+
         self.helper.join(
             room=room, user=yet_another_user_id, tok=yet_another_access_token
         )
@@ -364,7 +360,6 @@ class HTTPPusherTests(HomeserverTestCase):
 
         # Create a room
         room = self.helper.create_room_as(user_id, tok=access_token)
-        self.helper.invite (room, user_id, other_user_id, tok=access_token) # watcha+
 
         # The other user joins
         self.helper.join(room=room, user=other_user_id, tok=other_access_token)
@@ -408,7 +403,6 @@ class HTTPPusherTests(HomeserverTestCase):
         !watcha """
         self.assertEqual(self.push_attempts[0][1], "http://127.0.0.1:5000/_matrix/push/v1/notify") # watcha+
         self.assertEqual(self.push_attempts[0][2]["notification"]["prio"], "high")
-        self.helper.invite(room, user_id, yet_another_user_id, tok=access_token) # watcha+
 
         # Yet another user joins
         self.helper.join(
@@ -457,9 +451,7 @@ class HTTPPusherTests(HomeserverTestCase):
         room = self.helper.create_room_as(user_id, tok=access_token)
 
         # The other users join
-        self.helper.invite (room, user_id, other_user_id, tok=access_token) # watcha+
         self.helper.join(room=room, user=other_user_id, tok=other_access_token)
-        self.helper.invite (room, user_id, yet_another_user_id, tok=access_token) # watcha+
         self.helper.join(
             room=room, user=yet_another_user_id, tok=yet_another_access_token
         )
@@ -542,9 +534,7 @@ class HTTPPusherTests(HomeserverTestCase):
         room = self.helper.create_room_as(other_user_id, tok=other_access_token)
 
         # The other users join
-        self.helper.invite (room, other_user_id, user_id, tok=other_access_token) # watcha+
         self.helper.join(room=room, user=user_id, tok=access_token)
-        self.helper.invite (room, user_id, yet_another_user_id, tok=access_token) # watcha+
         self.helper.join(
             room=room, user=yet_another_user_id, tok=yet_another_access_token
         )
@@ -662,7 +652,6 @@ class HTTPPusherTests(HomeserverTestCase):
         room_id = self.helper.create_room_as(other_user_id, tok=other_access_token)
 
         # The user to get notified joins
-        self.helper.invite(room_id, other_user_id, user_id, tok=other_access_token) # watcha+
         self.helper.join(room=room_id, user=user_id, tok=access_token)
 
         # Register the pusher

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -232,9 +232,3 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
         self.replicate()
 
         return room
-
-    # watcha+
-    test_send_event_single_sender.skip = "Disabled for Watcha because private visibility of Watcha room scuttle the test. We have to find another way to force private visibility of rooms."
-    test_send_event_sharded.skip = "Disabled for Watcha because private visibility of Watcha room scuttle the test. We have to find another way to force private visibility of rooms."
-    test_send_typing_sharded.skip = "Disabled for Watcha because private visibility of Watcha room scuttle the test. We have to find another way to force private visibility of rooms."
-    # +watcha

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -77,7 +77,6 @@ class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
         room = self.helper.create_room_as(user_id, tok=access_token)
 
         # The other user joins
-        self.helper.invite(room, user_id, self.other_user_id, tok=access_token) # watcha+
         self.helper.join(
             room=room, user=self.other_user_id, tok=self.other_access_token
         )

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -308,10 +308,7 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
         non_admin_user = self.register_user("room_nonadmin", "pass", admin=False)
         non_admin_user_tok = self.login("room_nonadmin", "pass")
 
-        """ watcha!
         room_id = self.helper.create_room_as(non_admin_user, tok=admin_user_tok)
-        !watcha """
-        room_id = self.helper.create_room_as(non_admin_user, tok=non_admin_user_tok) # watcha+
         self.helper.join(room_id, non_admin_user, tok=non_admin_user_tok)
 
         # Upload some media

--- a/tests/rest/admin/test_event_reports.py
+++ b/tests/rest/admin/test_event_reports.py
@@ -41,13 +41,11 @@ class EventReportsTestCase(unittest.HomeserverTestCase):
         self.room_id1 = self.helper.create_room_as(
             self.other_user, tok=self.other_user_tok, is_public=True
         )
-        self.helper.invite(self.room_id1, self.other_user, self.admin_user, tok=self.other_user_tok) # watcha+
         self.helper.join(self.room_id1, user=self.admin_user, tok=self.admin_user_tok)
 
         self.room_id2 = self.helper.create_room_as(
             self.other_user, tok=self.other_user_tok, is_public=True
         )
-        self.helper.invite(self.room_id2, self.other_user, self.admin_user, tok=self.other_user_tok) # watcha+
         self.helper.join(self.room_id2, user=self.admin_user, tok=self.admin_user_tok)
 
         # Two rooms and two users. Every user sends and reports every room event

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -761,7 +761,6 @@ class RoomTestCase(unittest.HomeserverTestCase):
         # Have another user join the room
         user_2 = self.register_user("user4", "pass")
         user_tok_2 = self.login("user4", "pass")
-        self.helper.invite(room_id, self.admin_user, user_2, tok=self.admin_user_tok) # watcha+
         self.helper.join(room_id, user_2, tok=user_tok_2)
 
         # Create a new alias to this room
@@ -927,17 +926,14 @@ class RoomTestCase(unittest.HomeserverTestCase):
         # Set room member size in the reverse order. room 1 -> 1 member, 2 -> 2, 3 -> 3
         user_1 = self.register_user("bob1", "pass")
         user_1_tok = self.login("bob1", "pass")
-        self.helper.invite(room_id_2, self.admin_user, user_1, tok=self.admin_user_tok) # watcha+
         self.helper.join(room_id_2, user_1, tok=user_1_tok)
 
         user_2 = self.register_user("bob2", "pass")
         user_2_tok = self.login("bob2", "pass")
-        self.helper.invite(room_id_3, self.admin_user, user_2, tok=self.admin_user_tok) # watcha+
         self.helper.join(room_id_3, user_2, tok=user_2_tok)
 
         user_3 = self.register_user("bob3", "pass")
         user_3_tok = self.login("bob3", "pass")
-        self.helper.invite(room_id_3, self.admin_user, user_3, tok=self.admin_user_tok) # watcha+
         self.helper.join(room_id_3, user_3, tok=user_3_tok)
 
         # Test different sort orders, with forward and reverse directions
@@ -1123,7 +1119,6 @@ class RoomTestCase(unittest.HomeserverTestCase):
         # Have another user join the room
         user_1 = self.register_user("foo", "pass")
         user_tok_1 = self.login("foo", "pass")
-        self.helper.invite(room_id_1, self.admin_user, user_1, tok=self.admin_user_tok) # watcha+
         self.helper.join(room_id_1, user_1, tok=user_tok_1)
 
         url = "/_synapse/admin/v1/rooms/%s" % (room_id_1,)
@@ -1152,23 +1147,17 @@ class RoomTestCase(unittest.HomeserverTestCase):
         # Have another user join the room
         user_1 = self.register_user("foo", "pass")
         user_tok_1 = self.login("foo", "pass")
-        self.helper.invite(room_id_1, self.admin_user, user_1, tok=self.admin_user_tok) # watcha+
         self.helper.join(room_id_1, user_1, tok=user_tok_1)
 
         # Have another user join the room
         user_2 = self.register_user("bar", "pass")
         user_tok_2 = self.login("bar", "pass")
-        # watcha+
-        self.helper.invite(room_id_1, self.admin_user, user_2, tok=self.admin_user_tok)
-        self.helper.invite(room_id_2, self.admin_user, user_2, tok=self.admin_user_tok)
-        # +watcha
         self.helper.join(room_id_1, user_2, tok=user_tok_2)
         self.helper.join(room_id_2, user_2, tok=user_tok_2)
 
         # Have another user join the room
         user_3 = self.register_user("foobar", "pass")
         user_tok_3 = self.login("foobar", "pass")
-        self.helper.invite(room_id_2, self.admin_user, user_3, tok=self.admin_user_tok) # watcha+
         self.helper.join(room_id_2, user_3, tok=user_tok_3)
 
         url = "/_synapse/admin/v1/rooms/%s/members" % (room_id_1,)
@@ -1443,7 +1432,6 @@ class JoinAliasRoomTestCase(unittest.HomeserverTestCase):
         self.assertEquals(200, int(channel.result["code"]), msg=channel.result["body"])
         self.assertEqual(private_room_id, channel.json_body["joined_rooms"][0])
 
-    test_join_public_room.skip = "Disable for Watcha" # watcha+
 
 class MakeRoomAdminTestCase(unittest.HomeserverTestCase):
     servlets = [

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -2112,7 +2112,6 @@ class UserTokenRestTestCase(unittest.HomeserverTestCase):
         # Create a room as the admin user. This will bump the monthly active users to 1.
         room_id = self.helper.create_room_as(self.admin_user, tok=self.admin_user_tok)
 
-        self.helper.invite(room_id, self.admin_user, self.other_user, tok=self.admin_user_tok) # watcha+
         # Trying to join as the other user should fail due to reaching MAU limit.
         self.helper.join(
             room_id, user=self.other_user, tok=self.other_user_tok, expect_code=403

--- a/tests/rest/client/v1/test_directory.py
+++ b/tests/rest/client/v1/test_directory.py
@@ -72,11 +72,7 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
     def test_state_event_user_in_v5_room(self):
         """Test that a regular user can add alias events before room v6"""
         self.ensure_user_joined_room()
-        """ watcha!
-        # TBH not really sure why :) but stricter so OK :)
         self.set_alias_via_state_event(200)
-        !watcha """
-        self.set_alias_via_state_event(403) # watcha +
 
     @override_config({"default_room_version": 6})
     def test_state_event_v6_room(self):
@@ -86,10 +82,7 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
 
     def test_directory_in_room(self):
         self.ensure_user_joined_room()
-        """ watcha! - TBH not really sure why :) but stricter so OK :)
         self.set_alias_via_directory(200)
-        !watcha """
-        self.set_alias_via_directory(403) # watcha+
 
     def test_room_creation_too_long(self):
         url = "/_matrix/client/r0/createRoom"

--- a/tests/rest/client/v1/test_profile.py
+++ b/tests/rest/client/v1/test_profile.py
@@ -339,7 +339,6 @@ class ProfilesRestrictedTestCase(unittest.HomeserverTestCase):
     def test_in_shared_room(self):
         self.ensure_requester_left_room()
 
-        self.helper.invite(self.room_id, src=self.owner, tok=self.owner_tok, targ=self.requester) # watcha+
         self.helper.join(room=self.room_id, user=self.requester, tok=self.requester_tok)
 
         self.try_fetch_profile(200, self.requester_tok)

--- a/tests/rest/client/v1/test_rooms.py
+++ b/tests/rest/client/v1/test_rooms.py
@@ -1048,10 +1048,7 @@ class PublicRoomsRestrictedTestCase(unittest.HomeserverTestCase):
         tok = self.login("user", "pass")
 
         channel = self.make_request("GET", self.url, access_token=tok)
-        """ watcha!
         self.assertEqual(channel.code, 200, channel.result)
-        !watcha """
-        self.assertEqual(channel.code, 403, channel.result)  # watcha+
 
 
 class PerRoomProfilesForbiddenTestCase(unittest.HomeserverTestCase):

--- a/tests/rest/client/v1/test_typing.py
+++ b/tests/rest/client/v1/test_typing.py
@@ -91,7 +91,6 @@ class RoomTypingTestCase(unittest.HomeserverTestCase):
     def prepare(self, reactor, clock, hs):
         self.room_id = self.helper.create_room_as(self.user_id)
         # Need another user to make notifications actually work
-        self.helper.invite(self.room_id, src=self.user_id, targ="@jim:red") # watcha+
         self.helper.join(self.room_id, user="@jim:red")
 
     def test_set_typing(self):

--- a/tests/rest/client/v2_alpha/test_relations.py
+++ b/tests/rest/client/v2_alpha/test_relations.py
@@ -46,7 +46,6 @@ class RelationsTestCase(unittest.HomeserverTestCase):
         self.user2_id, self.user2_token = self._create_user("bob")
 
         self.room = self.helper.create_room_as(self.user_id, tok=self.user_token)
-        self.helper.invite(self.room, src=self.user_id, tok=self.user_token, targ=self.user2_id) # watcha+
         self.helper.join(self.room, user=self.user2_id, tok=self.user2_token)
         res = self.helper.send(self.room, body="Hi!", tok=self.user_token)
         self.parent_id = res["event_id"]
@@ -185,7 +184,6 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             user_id, token = self._create_user("test" + str(idx))
             idx += 1
 
-            self.helper.invite(self.room, src=self.user_id, tok=self.user_token, targ=user_id) # watcha+
             self.helper.join(self.room, user=user_id, tok=token)
             access_tokens.append(token)
 
@@ -252,7 +250,6 @@ class RelationsTestCase(unittest.HomeserverTestCase):
             user_id, token = self._create_user("test" + str(idx))
             idx += 1
 
-            self.helper.invite(self.room, src=self.user_id, tok=self.user_token, targ=user_id) # watcha+
             self.helper.join(self.room, user=user_id, tok=token)
             access_tokens.append(token)
 

--- a/tests/rest/client/v2_alpha/test_sync.py
+++ b/tests/rest/client/v2_alpha/test_sync.py
@@ -366,14 +366,6 @@ class UnreadMessagesTestCase(unittest.HomeserverTestCase):
         self._check_unread_count(0)
 
         # Join the new user and check that this doesn't increase the unread count.
-        # watcha+
-        self.helper.invite(
-            self.room_id,
-            self.user_id,
-            self.user2,
-            tok=self.tok,
-        )
-        # +watcha
         self.helper.join(room=self.room_id, user=self.user2, tok=self.tok2)
         self._check_unread_count(0)
 

--- a/tests/storage/test_cleanup_extrems.py
+++ b/tests/storage/test_cleanup_extrems.py
@@ -258,13 +258,7 @@ class CleanupExtremDummyEventsTestCase(HomeserverTestCase):
         self.event_creator_handler = homeserver.get_event_creation_handler()
 
         # Create a test user and room
-        """ watcha!
         self.user = UserID.from_string(self.register_user("user1", "password"))
-        !watcha """
-        # watcha+
-        self.user1 = self.register_user("user1", "password")
-        self.user = UserID.from_string(self.user1)
-        # +watcha
         self.token1 = self.login("user1", "password")
         self.requester = create_requester(self.user)
         info, _ = self.get_success(self.room_creator.create_room(self.requester, {}))
@@ -377,5 +371,3 @@ class CleanupExtremDummyEventsTestCase(HomeserverTestCase):
         consent_uri_builder = Mock()
         consent_uri_builder.build_user_consent_uri.return_value = "http://example.com"
         self.event_creator._consent_uri_builder = consent_uri_builder
-
-    test_send_dummy_events_when_insufficient_power.skip = "Disable for Watcha" # watcha+

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -332,9 +332,3 @@ class ExtremPruneTestCase(HomeserverTestCase):
 
         # Check the new extremity is just the new remote event.
         self.assert_extremities([local_message_event_id, remote_event_2.event_id])
-
-    # watcha+
-    test_prune_gap.skip = "Disabled for Watcha because private visibility of room scuttle the test. We have to find another way to force private visibility of rooms."
-    test_prune_gap_if_dummy_remote.skip = "Disabled for Watcha because private visibility of room scuttle the test. We have to find another way to force private visibility of rooms."
-    test_prune_gap_if_old.skip = "Disabled for Watcha because private visibility of room scuttle the test. We have to find another way to force private visibility of rooms."
-    # +watcha


### PR DESCRIPTION
# Objectif :

* Permettre à Synapse de gérer les salons publiques (suppression de code propre à Watcha).

# Résolution :

- Suppression du forçage de la visibilité du salon à "private".
- Suppression des erreurs 403 retournées par les API `/publicRooms`
- Nettoyages des tests.

# Remarques : 

- Des tests ont été effectués avec le client Riot. Le fonctionnement attendu est observable.

- Reste à confirmer avec le client Watcha : 
    - [x] La possibilité de créer un salon public.
    - [x] La possibilité de rejoindre un salon public sans y être invité.
    - [ ] Le répertoire d'utilisateur se comporte de façon identique avec les salons publiques (notamment concernant la visibilité limité des partenaires pour les autres utilisateurs).